### PR TITLE
Login API and option to not JSON parse tabulated data

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,104 +1,16 @@
 # Bamboozled
 
-[![Gem Version](https://badge.fury.io/rb/bamboozled.svg)](http://badge.fury.io/rb/bamboozled) [![Code Climate](https://codeclimate.com/github/Skookum/bamboozled.png)](https://codeclimate.com/github/Skookum/bamboozled) [![Build Status](https://travis-ci.org/Skookum/bamboozled.svg?branch=master)](https://travis-ci.org/Skookum/bamboozled)
-
-Bamboozled wraps the BambooHR API without the use of Rails dependencies. Currently, this gem is **READ-ONLY**.
+This fork of [Skookum/bamboozled](https://github.com/Skookum/bamboozled) includes the Login API from BambooHR.
 
 # Usage:
 
-Install the gem with `gem install bamboozled` or add this to your `Gemfile`: `gem 'bamboozled'`
-
 ```ruby
 # Create the client:
-client = Bamboozled.client(subdomain: 'your_subdomain', api_key: 'your_api_key')
+auth = Bamboozled.auth('your_app_id')
+response = auth.authenticate('subdomain', 'username', 'password')
 ```
 
-> TIP! Create an API key by logging into your BambooHR account, then click your image in the upper right corner and select "API Keys". Then click "Add A New Key".
-
-### Employee related data:
-
-You can pass an array of fields to `all` or `:all` to get all fields your user is allowed to access. Because BambooHR's API doesn't allow for specifying fields on the `/employees/directory` API endpoint, passing a list of fields to retrieve will be signifigantly slower than getting just the default fields since the gem will get the directory of employees, then request the data for each individual employee resulting in `employees.count + 1` API calls.
-
-```ruby
-# Returns an array of all employees
-client.employee.all # Gets all employees with default fields
-client.employee.all(:all) # Gets all fields for all employees
-client.employee.all(['hireDate', 'displayName'])
-client.employee.all('hireDate,displayName')
-
-# Returns a hash of a single employee
-client.employee.find(employee_id, fields = nil)
-
-# Tabular employee data
-client.employee.job_info(employee_id)
-client.employee.employment_status(employee_id)
-client.employee.compensation(employee_id)
-client.employee.dependents(employee_id)
-client.employee.contacts(employee_id)
-
-# Time off estimate for employee. Requires end date in Date or Time format or YY-MM-DD string.
-client.employee.time_off_estimate(employee_id, end_date)
-
-# Photos for an employee
-client.employee.photo_url(employee_work_email)
-client.employee.photo_url(employee_id)
-client.employee.photo_binary(employee_id)
-```
-
-### Time off data
-
-```ruby
-# Get time off requests filtered by a number of parameters
-# :id - the ID of the time off request
-# :action - 
-# :employeeId - the ID of the employee you're looking for
-# :start - filter start date
-# :end - filter end date
-# :type - type of time off request
-# :status - must be one or more of the following: approved denied superceded requested canceled
-client.time_off.requests(:employeeId: employee_id, start: Time.now)
-
-# See who is out when.
-client.time_off.whos_out(Time.now, '2014-12-31')
-```
-
-# Reports
-
-```ruby
-# Find a report by its number
-client.report.find(report_number, format = 'JSON', fd = true)
-```
-
-# Metadata
-
-```ruby
-# Get fields
-client.meta.fields
-# Get lists
-client.meta.lists
-# Get tables
-client.meta.tables
-# Get users
-# Note: this is all uses in the system, whereas client.employee.all only gets active employees
-client.meta.users
-```
-
-## Todo:
-
-1. Write more tests!
-2. Implement CRUD so the gem is not read-only any more.
-2. ~~Implement photos endpoints.~~
-3. ~~Implement metadata endpoints.~~
-4. Implement last change information endpoints.
-
-## Contributing
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Make some specs pass
-5. Push to the branch (`git push origin my-new-feature`)
-6. Create new Pull Request
+> TIP! You'll need to get an app_id from bambooHR.
 
 ## License
 

--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -6,6 +6,7 @@ require_relative './bamboozled/ext/yesno'
 
 require_relative './bamboozled/version'
 require_relative './bamboozled/errors'
+require_relative './bamboozled/auth'
 require_relative './bamboozled/base'
 
 %w(base employee report time_off meta).each {|a| require_relative "./bamboozled/api/#{a}"}
@@ -15,6 +16,11 @@ module Bamboozled
     # Creates a standard client that will raise all errors it encounters
     def client(subdomain: nil, api_key: nil)
       Bamboozled::Base.new(subdomain: subdomain, api_key: api_key)
+    end
+
+    # Creates an auth client that will raise all errors it encounters
+    def auth(app_key: nil)
+      Bamboozled::Auth.new(app_key: app_key)
     end
   end
 end

--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -19,8 +19,8 @@ module Bamboozled
     end
 
     # Creates an auth client that will raise all errors it encounters
-    def auth(app_key: nil)
-      Bamboozled::Auth.new(app_key: app_key)
+    def auth(app_key)
+      Bamboozled::Auth.new(app_key)
     end
   end
 end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -11,6 +11,8 @@ module Bamboozled
 
       protected
         def request(method, path, options = {})
+          options[:tabular] ||= false
+          tabular = options.delete(:tabular)
           params = {
             path:    path,
             options: options,
@@ -33,10 +35,18 @@ module Bamboozled
 
           case response.code
           when 200..201
-            begin
-              JSON.parse(response)
-            rescue
-              MultiXml.parse(response, symbolize_keys: true)
+            if tabular == true
+              begin
+                response
+              rescue
+                MultiXml.parse(response, symbolize_keys: true)
+              end
+            else
+              begin
+                JSON.parse(response)
+              rescue
+                MultiXml.parse(response, symbolize_keys: true)
+              end
             end
           when 400
             raise Bamboozled::BadRequest.new(response, params, 'The request was invalid or could not be understood by the server. Resubmitting the request will likely result in the same error.')

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -26,7 +26,7 @@ module Bamboozled
       # Tabular data
       [:job_info, :employment_status, :compensation, :dependents, :contacts].each do |action|
         define_method(action.to_s) do |argument_id|
-          request(:get, "employees/#{argument_id}/tables/#{action.to_s.gsub(/_(.)/) {|e| $1.upcase}}")
+          tabular_request(:get, "employees/#{argument_id}/tables/#{action.to_s.gsub(/_(.)/) {|e| $1.upcase}}")
         end
       end
 

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -26,7 +26,7 @@ module Bamboozled
       # Tabular data
       [:job_info, :employment_status, :compensation, :dependents, :contacts].each do |action|
         define_method(action.to_s) do |argument_id|
-          tabular_request(:get, "employees/#{argument_id}/tables/#{action.to_s.gsub(/_(.)/) {|e| $1.upcase}}")
+          request(:get, "employees/#{argument_id}/tables/#{action.to_s.gsub(/_(.)/) {|e| $1.upcase}}", {:tabular => true})
         end
       end
 

--- a/lib/bamboozled/api/meta.rb
+++ b/lib/bamboozled/api/meta.rb
@@ -3,9 +3,8 @@ module Bamboozled
     class Meta < Base
 
       [:field, :table, :list, :user].each do |action|
-        define_method("#{action}s") do
-          result = request(:get, "meta/#{action}s")
-          result["#{action}s".to_sym][action]
+        define_method(action.to_s}+"s") do
+          request(:get, "meta/#{action}s", {:tabular => true})
         end
       end
 

--- a/lib/bamboozled/api/meta.rb
+++ b/lib/bamboozled/api/meta.rb
@@ -3,8 +3,8 @@ module Bamboozled
     class Meta < Base
 
       [:field, :table, :list, :user].each do |action|
-        define_method(action.to_s}+"s") do
-          request(:get, "meta/#{action}s", {:tabular => true})
+        define_method(action.to_s+"s") do
+          request(:get, "meta/"+action.to_s+"s", {:tabular => true})
         end
       end
 

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -2,13 +2,13 @@ module Bamboozled
   class Auth
     attr_reader :request
 
-    def initialize(app_key: nil)
-      @app_key
+    def initialize(application_key)
+      @app_key = application_key
     end
 
-    def authenticate(subdomain, user, password)
-      @subdomain = subdomain
-      request(:post, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
+    def authenticate(company, user, password)
+      @subdomain = company
+      request(:post, "login", {:body => "applicationKey=#{@app_key}&user=#{user}&password=#{password}"})
     end
 
     protected

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -7,6 +7,7 @@ module Bamboozled
     end
 
     def authenticate(subdomain, user, password)
+      @subdomain = subdomain
       request(:get, "login", {:body => "applicationKey=#{@app_key}&user=#{user}&password=#{password}"})
     end
 
@@ -62,7 +63,7 @@ module Bamboozled
       end
 
       def path_prefix
-        "https://api.bamboohr.com/api/gateway.php/#{subdomain}/v1/"
+        "https://api.bamboohr.com/api/gateway.php/#{@subdomain}/v1/"
       end
   end
 end

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -8,7 +8,7 @@ module Bamboozled
 
     def authenticate(subdomain, user, password)
       @subdomain = subdomain
-      request(:get, "login", {:body => "applicationKey=#{@app_key}&user=#{user}&password=#{password}"})
+      request(:get, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
     end
 
     protected

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -1,0 +1,68 @@
+module Bamboozled
+  class Auth
+    attr_reader :request
+
+    def initialize(app_key: nil)
+      @app_key
+    end
+
+    def authenticate(subdomain, username, password)
+      request(:get, "login", {:body => "applicationKey=#{@app}"})
+    end
+
+    protected
+      def request(method, path, options = {})
+        params = {
+          path:    path,
+          options: options,
+          method:  method
+        }
+
+        httparty_options = {
+          query:  options[:query],
+          body:   options[:body],
+          format: :plain,
+          headers: {
+            "Accept"       => "application/json",
+            "User-Agent"   => "Bamboozled/#{Bamboozled::VERSION}"
+          }.update(options[:headers] || {})
+        }
+
+        response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
+        params[:response] = response.inspect.to_s
+
+        case response.code
+        when 200..201
+          begin
+            JSON.parse(response)
+          rescue
+            MultiXml.parse(response, symbolize_keys: true)
+          end
+        when 400
+          raise Bamboozled::BadRequest.new(response, params, 'The request was invalid or could not be understood by the server. Resubmitting the request will likely result in the same error.')
+        when 401
+          raise Bamboozled::AuthenticationFailed.new(response, params, 'Your App ID is missing.')
+        when 403
+          raise Bamboozled::Forbidden.new(response, params, 'The application is attempting to perform an action it does not have privileges to access. Verify your App ID has the required permissions.')
+        when 404
+          raise Bamboozled::NotFound.new(response, params, 'The resource was not found with the given identifier. Either the URL given is not a valid API, or the ID of the object specified in the request is invalid.')
+        when 406
+          raise Bamboozled::NotAcceptable.new(response, params, 'The request contains references to non-existent fields.')
+        when 409
+          raise Bamboozled::Conflict.new(response, params, 'The request attempts to create a duplicate. For employees, duplicate emails are not allowed. For lists, duplicate values are not allowed.')
+        when 500
+          raise Bamboozled::InternalServerError.new(response, params, 'The server encountered an error while processing your request and failed.')
+        when 502
+          raise Bamboozled::GatewayError.new(response, params, 'The load balancer or web server had trouble connecting to the Bamboo app. Please try the request again.')
+        when 503
+          raise Bamboozled::ServiceUnavailable.new(response, params, 'The service is temporarily unavailable. Please try the request again.')
+        else
+          raise Bamboozled::InformBamboo.new(response, params, 'An error occurred that we do not know how to handle. Please contact BambooHR.')
+        end
+      end
+
+      def path_prefix
+        "https://api.bamboohr.com/api/gateway.php/#{subdomain}/v1/"
+      end
+  end
+end

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -8,7 +8,7 @@ module Bamboozled
 
     def authenticate(company, user, password)
       @subdomain = company
-      request(:post, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
+      request(:post, "login", {:body => "applicationKey=#{@app_key}&user=#{CGI.escape(user)}&password=#{CGI.escape(password)}"})
     end
 
     protected

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -6,8 +6,8 @@ module Bamboozled
       @app_key
     end
 
-    def authenticate(subdomain, username, password)
-      request(:get, "login", {:body => "applicationKey=#{@app}"})
+    def authenticate(subdomain, user, password)
+      request(:get, "login", {:body => "applicationKey=#{@app_key}&user=#{user}&password=#{password}"})
     end
 
     protected

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -8,7 +8,7 @@ module Bamboozled
 
     def authenticate(subdomain, user, password)
       @subdomain = subdomain
-      request(:get, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
+      request(:post, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
     end
 
     protected

--- a/lib/bamboozled/auth.rb
+++ b/lib/bamboozled/auth.rb
@@ -8,7 +8,7 @@ module Bamboozled
 
     def authenticate(company, user, password)
       @subdomain = company
-      request(:post, "login", {:body => "applicationKey=#{@app_key}&user=#{user}&password=#{password}"})
+      request(:post, "login?applicationKey=#{@app_key}&user=#{user}&password=#{password}")
     end
 
     protected


### PR DESCRIPTION
This includes support for the login API, or at least the type that permits authentication with a username and password (not third party authentication). Upon making a request, tabular data includes a parameter in options that tells it not to JSONify the tabulated data so that the user may decide how to use the HTML that is returned from the API.
