### PR TITLE
Create employees

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,3 +42,6 @@ DEPENDENCIES
   rake
   turn
   webmock
+
+BUNDLED WITH
+   1.10.3

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -30,13 +30,15 @@ module Bamboozled
           }
 
           response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
-          binding.pry
           params[:response] = response.inspect.to_s
 
           case response.code
           when 200..201
             begin
-              JSON.parse(response.body).with_indifferent_access
+              res = JSON.parse(response.body).with_indifferent_access
+              headers = response.headers.to_h
+              res[:headers] = headers
+              res
             rescue
               MultiXml.parse(response, symbolize_keys: true)
             end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -30,12 +30,13 @@ module Bamboozled
           }
 
           response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
+          binding.pry
           params[:response] = response.inspect.to_s
 
           case response.code
           when 200..201
             begin
-              JSON.parse(response).with_indifferent_access
+              JSON.parse(response.body).with_indifferent_access
             rescue
               MultiXml.parse(response, symbolize_keys: true)
             end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -35,7 +35,7 @@ module Bamboozled
           case response.code
           when 200..201
             begin
-              if response.nil?
+              if response.body.to_s.empty?
                 {"headers" => response.headers}.with_indifferent_access
               else
                 JSON.parse(response.body).with_indifferent_access

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -35,10 +35,11 @@ module Bamboozled
           case response.code
           when 200..201
             begin
-              res = JSON.parse(response.body).with_indifferent_access
-              headers = response.headers.to_h
-              res[:headers] = headers
-              res
+              if response.nil?
+                {"headers" => response.headers}.with_indifferent_access
+              else
+                JSON.parse(response.body).with_indifferent_access
+              end
             rescue
               MultiXml.parse(response, symbolize_keys: true)
             end

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -30,17 +30,6 @@ module Bamboozled
         end
       end
 
-      def new(employee_details:)
-        details = employee_details.map { |k,v| "<field id='#{k}'>#{v}</field>" }
-        details.unshift("<employee>")
-        details.push("</employee>")
-        details = details.join("")
-
-        options = {body: details}
-
-        request(:post, "employees/", options)
-      end
-
       def time_off_estimate(employee_id, end_date)
         end_date = end_date.strftime("%F") unless end_date.is_a?(String)
         request(:get, "employees/#{employee_id}/time_off/calculator?end=#{end_date}")
@@ -65,6 +54,21 @@ module Bamboozled
         "http://#{@subdomain}.bamboohr.com/employees/photos/?h=#{digest}"
       end
 
+      def add(employee_details:)
+        details = generate_xml(employee_details)
+        options = {body: details}
+
+        request(:post, "employees/", options)
+      end
+
+      private
+
+      def generate_xml(employee_details)
+        details = employee_details.map { |k,v| "<field id='#{k}'>#{v}</field>" }
+        details.unshift("<employee>")
+        details.push("</employee>")
+        details = details.join("")
+      end
     end
   end
 end

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -30,6 +30,17 @@ module Bamboozled
         end
       end
 
+      def new(employee_details:)
+        details = employee_details.map { |k,v| "<field id='#{k}'>#{v}</field>" }
+        details.unshift("<employee>")
+        details.push("</employee>")
+        details = details.join("")
+
+        options = {body: details}
+
+        request(:post, "employees/", options)
+      end
+
       def time_off_estimate(employee_id, end_date)
         end_date = end_date.strftime("%F") unless end_date.is_a?(String)
         request(:get, "employees/#{employee_id}/time_off/calculator?end=#{end_date}")

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -64,10 +64,11 @@ module Bamboozled
       private
 
       def generate_xml(employee_details)
-        details = employee_details.map { |k,v| "<field id='#{k}'>#{v}</field>" }
-        details.unshift("<employee>")
-        details.push("</employee>")
-        details = details.join("")
+        "".tap do |xml|
+          xml << "<employee>"
+          employee_details.each { |k, v| xml << "<field id='#{k}'>#{v}</field>" }
+          xml << "</employee>"
+        end
       end
     end
   end

--- a/spec/fixtures/add_employee.json
+++ b/spec/fixtures/add_employee.json
@@ -1,6 +1,0 @@
-HTTP/1.1 200 OK
-content-type: application/json; charset=utf-8
-date: Tue, 17 Jun 2014 19:25:35 UTC
-location: https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259
-
-{}

--- a/spec/fixtures/add_employee.json
+++ b/spec/fixtures/add_employee.json
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+date: Tue, 17 Jun 2014 19:25:35 UTC
+location: https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259
+
+{}

--- a/spec/fixtures/add_employee_details.json
+++ b/spec/fixtures/add_employee_details.json
@@ -1,0 +1,7 @@
+{
+  "firstName": "Bruce",
+  "lastName": "Wayne",
+  "workEmail": "bruce.wayne@gmail.com",
+  "jobTitle": "Batman",
+  "city": "Gotham"
+}

--- a/spec/fixtures/add_employee_response.json
+++ b/spec/fixtures/add_employee_response.json
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+date: Tue, 17 Jun 2014 19:25:35 UTC
+location: https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259
+

--- a/spec/fixtures/add_employee_xml.yml
+++ b/spec/fixtures/add_employee_xml.yml
@@ -1,0 +1,8 @@
+body:
+  <employee><field id='firstName'>Bruce</field><field id='lastName'>Wayne</field><field id='workEmail'>bruce.wayne@gmail.com</field><field id='jobTitle'>Batman</field><field id='city'>Gotham</field></employee>
+headers:
+  Accept:
+  - application/json
+  User-Agent:
+  - Bamboozled/0.0.7
+

--- a/spec/lib/bamboozled/employee_spec.rb
+++ b/spec/lib/bamboozled/employee_spec.rb
@@ -100,6 +100,35 @@ describe "Employees" do
     url.must_equal required_url
   end
 
+  it 'creates a new employee in BambooHR' do
+    details = {
+      firstName: "Bruce",
+      lastName: "Wayne",
+      workEmail: "bruce.wayne@gmail.com",
+      jobTitle: "Batman",
+      city: "Gotham"
+    }
+
+    xml_string = <<-XML.gsub(/^\s+/, '').gsub("\n", '')
+    <employee><field id='firstName'>Bruce</field>
+    <field id='lastName'>Wayne</field>
+    <field id='workEmail'>bruce.wayne@gmail.com</field>
+    <field id='jobTitle'>Batman</field>
+    <field id='city'>Gotham</field>
+    </employee>
+    XML
+
+    response = File.new('spec/fixtures/add_employee.json')
+
+    stub_request(:post, /.*api\.bamboohr\.com.*/).
+      with(body: xml_string).to_return(response)
+
+    employee = @client.employee.add(employee_details: details)
+
+    employee["headers"]["location"].
+      must_equal ["https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"]
+  end
+
   # TODO - Figure out how to test this with webmock
   # it 'returns binary data for an employee photo' do
   # end

--- a/spec/lib/bamboozled/employee_spec.rb
+++ b/spec/lib/bamboozled/employee_spec.rb
@@ -100,33 +100,21 @@ describe "Employees" do
     url.must_equal required_url
   end
 
-  it 'creates a new employee in BambooHR' do
-    details = {
-      firstName: "Bruce",
-      lastName: "Wayne",
-      workEmail: "bruce.wayne@gmail.com",
-      jobTitle: "Batman",
-      city: "Gotham"
-    }
+  describe "#add" do
+    it 'creates a new employee in BambooHR' do
 
-    xml_string = <<-XML.gsub(/^\s+/, '').gsub("\n", '')
-    <employee><field id='firstName'>Bruce</field>
-    <field id='lastName'>Wayne</field>
-    <field id='workEmail'>bruce.wayne@gmail.com</field>
-    <field id='jobTitle'>Batman</field>
-    <field id='city'>Gotham</field>
-    </employee>
-    XML
+      xml = YAML.load_file('spec/fixtures/add_employee_xml.yml')
+      response = File.new('spec/fixtures/add_employee_response.json')
+      details = JSON.parse(File.read('spec/fixtures/add_employee_details.json'))
 
-    headers = {"content-type"=>["application/json; charset=utf-8"], "date"=>["Tue, 17 Jun 2014 19:25:35 UTC"], "location"=>["https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"]}
+      stub_request(:post, /.*api\.bamboohr\.com.*/).
+        with(xml).to_return(response)
 
-    stub_request(:post, /.*api\.bamboohr\.com.*/).
-      with(body: xml_string).to_return(body: "", headers: headers)
+      employee = @client.employee.add(employee_details: details)
 
-    employee = @client.employee.add(employee_details: details)
-
-    employee["headers"]["location"].
-      must_equal "https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"
+      employee["headers"]["location"].
+        must_equal "https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"
+    end
   end
 
   # TODO - Figure out how to test this with webmock
@@ -134,3 +122,4 @@ describe "Employees" do
   # end
 
 end
+

--- a/spec/lib/bamboozled/employee_spec.rb
+++ b/spec/lib/bamboozled/employee_spec.rb
@@ -23,7 +23,7 @@ describe "Employees" do
     employee = @client.employee.find(1234)
 
     employee.is_a?(Hash).must_equal true
-    employee.count.must_equal 4
+    employee.count.must_equal 3
     employee['firstName'].must_equal "John"
     employee['lastName'].must_equal "Doe"
   end
@@ -118,15 +118,15 @@ describe "Employees" do
     </employee>
     XML
 
-    response = File.new('spec/fixtures/add_employee.json')
+    headers = {"content-type"=>["application/json; charset=utf-8"], "date"=>["Tue, 17 Jun 2014 19:25:35 UTC"], "location"=>["https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"]}
 
     stub_request(:post, /.*api\.bamboohr\.com.*/).
-      with(body: xml_string).to_return(response)
+      with(body: xml_string).to_return(body: "", headers: headers)
 
     employee = @client.employee.add(employee_details: details)
 
     employee["headers"]["location"].
-      must_equal ["https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"]
+      must_equal "https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"
   end
 
   # TODO - Figure out how to test this with webmock

--- a/spec/lib/bamboozled/employee_spec.rb
+++ b/spec/lib/bamboozled/employee_spec.rb
@@ -23,7 +23,7 @@ describe "Employees" do
     employee = @client.employee.find(1234)
 
     employee.is_a?(Hash).must_equal true
-    employee.count.must_equal 3
+    employee.count.must_equal 4
     employee['firstName'].must_equal "John"
     employee['lastName'].must_equal "Doe"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,3 @@ require_relative '../lib/bamboozled'
 #dependencies
 require 'minitest/autorun'
 require 'webmock/minitest'
-
-require 'turn'
-
-Turn.config do |c|
- # :outline  - turn's original case/test outline mode [default]
- c.format  = :outline
- # turn on invoke/execute tracing, enable full backtrace
- c.trace   = true
- # use humanized test names (works only with :outline format)
- c.natural = true
-end


### PR DESCRIPTION
## What's Up 

Currently bamboozled is only able to read data from BambooHR accounts. This PR adds the ability to create new employees and will be followed by a PR to allow for the updating employee data.

## Changes

### 1. Bamboozled::API::Employee & Spec
* Added an #add_employee method that takes a hash of employee details, converts the hash into the valid XML string, and calls the request method to POST the data to the BambooHR API and create a new employee.

* Added a test for this method in the employee_spec.rb file.

### 2. Bamboozled::API::Base 
* The `response` was being parsed by JSON.parse  This was changed to `response.body` becuase 1) it makes more sense and 2) it will cause an error when posting data to BambooHR successfully becuase the `response.parsed_response` is nil  

* The `response.headers` are added to the response hash returned by the #request method.  This is becuase after a new employee has been created the headers include the "location" i.e. the link for to the employee's page on BambooHR, which contains their BambooHR ID.  Most likely if you're creating an employee via the API you're going to want to store the employee's BambooHR ID some where.
