### PR TITLE
WIP: Add row tabular data

### DIFF
--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -8,7 +8,9 @@ require_relative './bamboozled/version'
 require_relative './bamboozled/errors'
 require_relative './bamboozled/base'
 
-%w(base employee report time_off meta).each {|a| require_relative "./bamboozled/api/#{a}"}
+%w(base employee report time_off meta tabular).each do |a|
+  require_relative "./bamboozled/api/#{a}"
+end
 
 module Bamboozled
   class << self

--- a/lib/bamboozled/api/tabular.rb
+++ b/lib/bamboozled/api/tabular.rb
@@ -1,0 +1,23 @@
+module Bamboozled
+  module API
+    class Tabular < Base
+      def add_row(table_name: nil, columns: {}, employee_id: nil)
+        url = "employees/#{employee_id}/tables/#{table_name}"
+        row_data = generate_xml(columns)
+        options = { body: row_data }
+
+        request(:post, url, options)
+      end
+
+      private
+
+      def generate_xml(columns)
+        "".tap do |xml|
+          xml << "<row>"
+          columns.each { |k, v| xml << "<field id='#{k}'>#{v}</field>" }
+          xml << "</row>"
+        end
+      end
+    end
+  end
+end

--- a/lib/bamboozled/base.rb
+++ b/lib/bamboozled/base.rb
@@ -21,5 +21,9 @@ module Bamboozled
     def time_off
       @time_off ||= Bamboozled::API::TimeOff.new(@subdomain, @api_key)
     end
+
+    def tabular
+      @tabular ||= Bamboozled::API::Tabular.new(@subdomain, @api_key)
+    end
   end
 end


### PR DESCRIPTION
## What's up 
The BambooHR API allows you to add rows to the following tables: jobInfo, employmentStatus, compensation, dependentsemergencyContacts or (contacts), and custom tables (customTableName). To make this possible in Bamboozled we need a Tabular class that takes the table name, columns, and employee id. Note: the #generate_xml class is duplicating code from the employee class but I want to wait to extract this into a module or the Base class.