### PR TITLE
Add support for employee last changed API endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
 end
 
 group :development, :test do
-  gem "listen", "3.1.1"
+  gem "listen", "3.0.7"
   gem "guard"
   gem "guard-rspec", require: false
   gem "rubocop", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "listen", "3.1.1"
   gem "guard"
   gem "guard-rspec", require: false
   gem "rubocop", require: false

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ client.employee.all(:all) # Gets all fields for all employees
 client.employee.all(["hireDate", "displayName"])
 client.employee.all("hireDate,displayName")
 
+# Get the employee records which have changed since a given date
+client.employee.last_changed("2015-01-01T00:00:00-08:00", :updated)
+client.employee.last_changed("2015-01-01T00:00:00-08:00", :inserted)
+client.employee.last_changed("2015-01-01T00:00:00-08:00", :deleted)
+client.employee.last_changed("2015-01-01T00:00:00-08:00") # Return all changes
+
 # Returns a hash of a single employee
 client.employee.find(employee_id, fields = nil)
 

--- a/bamboozled.gemspec
+++ b/bamboozled.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "httparty", "~> 0.13"
   spec.add_dependency "json", "~> 1.8"
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "activesupport"
 end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'time'
+require "time"
 require 'active_support/core_ext/hash/indifferent_access'
 
 module Bamboozled

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'time'
 require 'active_support/core_ext/hash/indifferent_access'
 
 module Bamboozled

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -24,12 +24,12 @@ module Bamboozled
       end
 
       def last_changed(date = "2011-06-05T00:00:00+00:00", type = nil)
-        query = {}
+        query = Hash.new
         query[:since] = date.respond_to?(:iso8601) ? date.iso8601 : date
         query[:type] = type unless type.nil?
 
-        response = request(:get, "employees/changed", {query: query})
-        response['employees']
+        response = request(:get, "employees/changed", query: query)
+        response["employees"]
       end
 
       # Tabular data

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -25,11 +25,11 @@ module Bamboozled
 
       def last_changed(date = "2011-06-05T00:00:00+00:00", type = nil)
         query = {
-          since:  date.respond_to?(:iso8601) ? date.iso8601 : date,
-          type: type
+          since:  date.respond_to?(:iso8601) ? date.iso8601 : date
         }
+        query[:type] = type unless type.nil?
 
-        response = request(:get, "employees/changed", query)
+        response = request(:get, "employees/changed", {query: query})
         response['employees']
       end
 

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -24,9 +24,8 @@ module Bamboozled
       end
 
       def last_changed(date = "2011-06-05T00:00:00+00:00", type = nil)
-        query = {
-          since:  date.respond_to?(:iso8601) ? date.iso8601 : date
-        }
+        query = {}
+        query[:since] = date.respond_to?(:iso8601) ? date.iso8601 : date
         query[:type] = type unless type.nil?
 
         response = request(:get, "employees/changed", {query: query})

--- a/lib/bamboozled/api/employee.rb
+++ b/lib/bamboozled/api/employee.rb
@@ -23,6 +23,16 @@ module Bamboozled
         request(:get, "employees/#{employee_id}?fields=#{fields}")
       end
 
+      def last_changed(date = "2011-06-05T00:00:00+00:00", type = nil)
+        query = {
+          since:  date.respond_to?(:iso8601) ? date.iso8601 : date,
+          type: type
+        }
+
+        response = request(:get, "employees/changed", query)
+        response['employees']
+      end
+
       # Tabular data
       [:job_info, :employment_status, :compensation, :dependents, :contacts].each do |action|
         define_method(action.to_s) do |argument_id|

--- a/spec/fixtures/last_changed.json
+++ b/spec/fixtures/last_changed.json
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+date: Tue, 17 Jun 2014 19:25:35 UTC
+
+{
+  "employees": {
+    "3": {
+      "id":"3",
+      "action":"Inserted",
+      "lastChanged":"2011-06-02T19:26:23+00:00"
+    },
+    "4": {
+      "id":"4",
+      "action":"Updated",
+      "lastChanged":"2011-06-02T19:26:23+00:00"
+    },
+    "5": {
+      "id":"5",
+      "action":"Deleted",
+      "lastChanged":"2011-06-02T19:26:23+00:00"
+    },
+    "10": {
+      "id":"10",
+      "action":"Inserted",
+      "lastChanged":"2011-05-31T22:57:10+00:00"
+    }
+  }
+}

--- a/spec/lib/bamboozled/api/employee_spec.rb
+++ b/spec/lib/bamboozled/api/employee_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe "Employees" do
     expect(url).to eq required_url
   end
 
+  it "Gets all employee records which have changed since a given date" do
+    response = File.new("spec/fixtures/last_changed.json")
+    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+    employees = @client.employee.last_changed("2011-06-02T19:26:23+00:00")
+
+    expect(employees).to be_a Hash
+    expect(employees.keys.count).to eq 4
+  end
+
   describe "#add" do
     it "creates a new employee in BambooHR" do
       xml = YAML.load_file("spec/fixtures/add_employee_xml.yml")


### PR DESCRIPTION
- Query the most recently changed employees
- Scope to updated, inserted, deleted, or return all changes
- Remove unneeded AS version dependency (it causes dependency conflicts, locks out old rails users)