### PR TITLE
Configure CI to run Pronto

### DIFF
--- a/.pronto.yml
+++ b/.pronto.yml
@@ -1,0 +1,2 @@
+max_warnings: 150
+verbose: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 2.0.0
   - 2.1
@@ -13,10 +14,13 @@ install:
 
 script:
   - bundle exec rspec
-  - bundle exec pronto run -f github_pr -c origin/master
+  - bundle exec pronto run -f github_status github_pr -c origin/master
 
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+
+env:
+  - PULL_REQUEST_ID = ${TRAVIS_PULL_REQUEST}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - bundle exec rspec
-  - bundle exec pronto run -f github_status github_pr -c origin/master
+  - bundle exec pronto run -f github_pr -c origin/master
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: ruby
-sudo: false
-cache: bundler
 rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
   - ruby-head
   - jruby-head
+
+before_install: gem update --remote bundler && bundle --version
+install:
+  - bundle install --retry=3
+
+script:
+  - bundle exec rspec
+  - bundle exec pronto run -f github_status github_pr -c origin/master
+
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-before_install: gem update --remote bundler && bundle --version
-install:
-  - bundle install --retry=3
-script:
-  - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
   - ruby-head
   - jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3.0
-  - ruby-head
-  - jruby-head
 
 before_install: gem update --remote bundler && bundle --version
 install:
   - bundle install --retry=3
+  - echo $TRAVIS_PULL_REQUEST
+  - echo $PULL_REQUEST_ID
 
 script:
   - bundle exec rspec
-  - bundle exec pronto run -f github_status github_pr -c origin/master
+  - PULL_REQUEST_ID=${TRAVIS_PULL_REQUEST} bundle exec pronto run -f github_status github_pr -c origin/master
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: ruby
 sudo: false
 rvm:
+  - 2.0.0
+  - 2.1
+  - 2.2
   - 2.3.0
+  - ruby-head
+  - jruby-head
 
 before_install: gem update --remote bundler && bundle --version
 install:
   - bundle install --retry=3
-  - echo $TRAVIS_PULL_REQUEST
-  - echo $PULL_REQUEST_ID
 
 script:
   - bundle exec rspec
@@ -18,6 +21,3 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-
-env:
-  - PULL_REQUEST_ID = ${TRAVIS_PULL_REQUEST}

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,13 @@ group :development, :test do
   gem "listen", "3.0.7"
   gem "guard"
   gem "guard-rspec", require: false
+  gem "guard-rubocop", require: false
   gem "rubocop", require: false
   gem "rubocop-rspec", require: false
-  gem "guard-rubocop", require: false
+
+  gem "pronto"
+  gem "pronto-rubocop", require: false
+  gem "pronto-flay", require: false
+  gem "pronto-reek", require: false
+  gem "pronto-brakeman", require: false
 end


### PR DESCRIPTION
This commit introduces Pronto to execute several runners on every pull request
diff to master. The runners include: `Rubocop`, `Flay`, `Reek`, and `Brakeman`.

Resolves: #21