### PR TITLE
Fix failing tests that used real HTTP requests

### DIFF
--- a/spec/fixtures/add_employee_xml.yml
+++ b/spec/fixtures/add_employee_xml.yml
@@ -4,5 +4,5 @@ headers:
   Accept:
   - application/json
   User-Agent:
-  - Bamboozled/0.0.7
+  - Bamboozled/0.1.0
 

--- a/spec/fixtures/update_employee_xml.yml
+++ b/spec/fixtures/update_employee_xml.yml
@@ -4,5 +4,5 @@ headers:
   Accept:
   - application/json
   User-Agent:
-  - Bamboozled/0.0.7
+  - Bamboozled/0.1.0
 


### PR DESCRIPTION
A couple of the HTTP requests were stubbed with the previous gem version causing
a mismatch that triggered a real network request. This commit simply updates the
fixtures to use the newer version of the gem as the user agent.