### PR TITLE
Remove Active Support dependency

### DIFF
--- a/bamboozled.gemspec
+++ b/bamboozled.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "httparty", "~> 0.13"
   spec.add_dependency "json", "~> 1.8"
-  spec.add_dependency "activesupport"
 end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -1,6 +1,5 @@
 require 'json'
 require "time"
-require 'active_support/core_ext/hash/indifferent_access'
 
 module Bamboozled
   module API
@@ -37,9 +36,9 @@ module Bamboozled
           when 200..201
             begin
               if response.body.to_s.empty?
-                {"headers" => response.headers}.with_indifferent_access
+                { "headers" => response.headers }
               else
-                JSON.parse(response.body).with_indifferent_access
+                JSON.parse(response)
               end
             rescue
               MultiXml.parse(response, symbolize_keys: true)

--- a/spec/lib/bamboozled/api/employee_spec.rb
+++ b/spec/lib/bamboozled/api/employee_spec.rb
@@ -5,20 +5,6 @@ RSpec.describe "Employees" do
     @client = Bamboozled.client(subdomain: "x", api_key: "x")
   end
 
-  it "Gets data in a hash with indifferent access" do
-    response = File.new("spec/fixtures/one_employee.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-    employee = @client.employee.find(1234)
-
-    expect(employee).to be_a Hash
-    expect(employee.count).to eq 3
-    expect(employee["firstName"]).to eq "John"
-    expect(employee[:firstName]).to eq "John"
-    expect(employee["lastName"]).to eq "Doe"
-    expect(employee[:lastName]).to eq "Doe"
-  end
-
   it "Gets all employees" do
     response = File.new("spec/fixtures/all_employees.json")
     stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)


### PR DESCRIPTION
This commit removes **Active Support** as a dependency in favor of defaulting to
strings for `Hash` access. Active Support is currently being used solely for a
couple of instances of `hash_with_indifferent_access`. We can keep `Bamboozled`
smaller and delegate the use of such libraries to the user when reading a
response.

Resolves: #23