### PR TITLE
Update Bamboozled::API::Meta to match API responses from Bamboo

### DIFF
--- a/lib/bamboozled/api/meta.rb
+++ b/lib/bamboozled/api/meta.rb
@@ -2,13 +2,39 @@ module Bamboozled
   module API
     class Meta < Base
 
-      [:field, :table, :list, :user].each do |action|
-        define_method("#{action}s") do
-          result = request(:get, "meta/#{action}s")
-          result["#{action}s".to_sym][action]
-        end
+      # Public: Get a list of fields.
+      # See https://www.bamboohr.com/api/documentation/metadata.php#getFields
+      #
+      # Returns an Array.
+      def fields
+        request(:get, "meta/fields")
       end
 
+      # Public: Get the details for "list" fields in an account.
+      # See https://www.bamboohr.com/api/documentation/metadata.php#getLists
+      #
+      # Returns an Array.
+      def lists
+        result = request(:get, "meta/lists")
+        result[:lists][:list]
+      end
+
+      # Public: Get a list of tabular fields.
+      # See https://www.bamboohr.com/api/documentation/metadata.php#getTables
+      #
+      # Returns an Array.
+      def tables
+        result = request(:get, "meta/tables")
+        result[:tables][:table]
+      end
+
+      # Public: Get a list of users.
+      # See https://www.bamboohr.com/api/documentation/metadata.php#getUsers
+      #
+      # Returns an Array.
+      def users
+        request(:get, "meta/users").values
+      end
     end
   end
 end


### PR DESCRIPTION
Fix `Bamboozled::API::Meta` to work with responses from [Bamboo Metadata API](https://www.bamboohr.com/api/documentation/metadata.php).

- [x] Update implementation
- [ ] Add tests

Potentially closes https://github.com/Skookum/bamboozled/issues/36

/cc @spicycode