### PR TITLE
Allow API domain to be specified

### DIFF
--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -16,8 +16,9 @@ require "bamboozled/api/meta"
 module Bamboozled
   class << self
     # Creates a standard client that will raise all errors it encounters
-    def client(subdomain: nil, api_key: nil, httparty_options: {})
-      Bamboozled::Base.new(subdomain: subdomain, api_key: api_key, httparty_options: httparty_options)
+    def client(subdomain: nil, api_domain: nil, api_key: nil, httparty_options: {})
+      Bamboozled::Base.new(subdomain: subdomain, api_domain: api_domain, api_key: api_key,
+                           httparty_options: httparty_options)
     end
   end
 end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -6,8 +6,13 @@ module Bamboozled
     class Base
       attr_reader :subdomain, :api_key
 
-      def initialize(subdomain, api_key, httparty_options = {})
-        @subdomain = subdomain
+      def initialize(domain_options, api_key, httparty_options = {})
+        if domain_options.is_a?(Hash)
+          @subdomain = domain_options[:subdomain]
+          @api_domain = domain_options[:api_domain]
+        else
+          @subdomain = domain_options
+        end
         @api_key = api_key
         @httparty_options = httparty_options || {}
       end
@@ -78,7 +83,8 @@ module Bamboozled
         end
 
         def path_prefix
-          "https://api.bamboohr.com/api/gateway.php/#{subdomain}/v1/"
+          api_domain = @api_domain || 'api.bamboohr.com'
+          "https://#{api_domain}/api/gateway.php/#{subdomain}/v1/"
         end
     end
   end

--- a/lib/bamboozled/base.rb
+++ b/lib/bamboozled/base.rb
@@ -2,30 +2,40 @@ module Bamboozled
   class Base
     attr_reader :request
 
-    def initialize(subdomain: nil, api_key: nil, httparty_options: {})
+    def initialize(subdomain: nil, api_domain: nil, api_key: nil, httparty_options: {})
       @subdomain, @api_key = subdomain
+      @api_domain = api_domain
       @api_key = api_key
       @httparty_options = httparty_options
     end
 
     def employee
-      @employee ||= Bamboozled::API::Employee.new(@subdomain, @api_key, @httparty_options)
+      @employee ||= Bamboozled::API::Employee.new(domain_options, @api_key, @httparty_options)
     end
 
     def report
-      @report ||= Bamboozled::API::Report.new(@subdomain, @api_key, @httparty_options)
+      @report ||= Bamboozled::API::Report.new(domain_options, @api_key, @httparty_options)
     end
 
     def meta
-      @meta ||= Bamboozled::API::Meta.new(@subdomain, @api_key, @httparty_options)
+      @meta ||= Bamboozled::API::Meta.new(domain_options, @api_key, @httparty_options)
     end
 
     def time_off
-      @time_off ||= Bamboozled::API::TimeOff.new(@subdomain, @api_key, @httparty_options)
+      @time_off ||= Bamboozled::API::TimeOff.new(domain_options, @api_key, @httparty_options)
     end
 
     def time_tracking
-      @time_tracking ||= Bamboozled::API::TimeTracking.new(@subdomain, @api_key, @httparty_options)
+      @time_tracking ||= Bamboozled::API::TimeTracking.new(domain_options, @api_key, @httparty_options)
+    end
+
+    protected
+
+    def domain_options
+      {
+        subdomain: @subdomain,
+        api_domain: @api_domain
+      }
     end
   end
 end

--- a/spec/lib/bamboozled/api/base_spec.rb
+++ b/spec/lib/bamboozled/api/base_spec.rb
@@ -1,6 +1,23 @@
 require "spec_helper"
 
 RSpec.describe "Bamboozled::API::Base" do
+  it "accepts a hash as first constructor parameter" do
+    expect do
+      Bamboozled::API::Base.new({ subdomain: 'x', api_domain: 'api.bamboohr.co.uk' }, "x", { log_format: :curl })
+    end.not_to raise_error
+  end
+
+  it "uses subdomain and api_domain from first parameter if has provided" do
+    response = double("response", code: 200, body: "{}", to_str: "{}")
+
+    expect(HTTParty).to receive(:get).
+      with("https://api.bamboohr.co.uk/api/gateway.php/x/v1/test", hash_including(log_format: :curl)).
+      and_return(response)
+
+    base = Bamboozled::API::Base.new({ subdomain: 'x', api_domain: 'api.bamboohr.co.uk' }, "x", { log_format: :curl })
+    base.send(:request, :get, "test")
+  end
+
   it "takes HTTParty options as a constructor parameter" do
     expect { Bamboozled::API::Base.new("x", "x", { log_format: :curl }) }.not_to raise_error
   end

--- a/spec/lib/bamboozled/api/employee_spec.rb
+++ b/spec/lib/bamboozled/api/employee_spec.rb
@@ -1,140 +1,158 @@
 require "spec_helper"
 
 RSpec.describe "Employees" do
-  before do
-    @client = Bamboozled.client(subdomain: "x", api_key: "x")
+  context 'UK domain specified' do
+    before do
+      @client = Bamboozled.client(subdomain: "x", api_domain: 'api.bamboohr.co.uk', api_key: "x")
+    end
+
+    it "Gets all employees from UK domain if specified" do
+      response = File.new("spec/fixtures/all_employees.json")
+      stub_request(:any, /.*api\.bamboohr\.co\.uk.*/).to_return(response)
+
+      employees = @client.employee.all
+
+      expect(employees).to be_a Array
+      expect(employees.first.count).to eq 7
+    end
   end
 
-  it "Gets all employees" do
-    response = File.new("spec/fixtures/all_employees.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+  context 'no api domain specified' do
+    before do
+      @client = Bamboozled.client(subdomain: "x", api_key: "x")
+    end
 
-    employees = @client.employee.all
+    it "Gets all employees" do
+      response = File.new("spec/fixtures/all_employees.json")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
-    expect(employees).to be_a Array
-    expect(employees.first.count).to eq 7
-  end
+      employees = @client.employee.all
 
-  it "Gets one employee" do
-    response = File.new("spec/fixtures/one_employee.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+      expect(employees).to be_a Array
+      expect(employees.first.count).to eq 7
+    end
 
-    employee = @client.employee.find(1234)
+    it "Gets one employee" do
+      response = File.new("spec/fixtures/one_employee.json")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
-    expect(employee).to be_a Hash
-    expect(employee.count).to eq 3
-    expect(employee["firstName"]).to eq "John"
-    expect(employee["lastName"]).to eq "Doe"
-  end
+      employee = @client.employee.find(1234)
 
-  it "Gets employee job info" do
-    response = File.new("spec/fixtures/job_info.xml")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+      expect(employee).to be_a Hash
+      expect(employee.count).to eq 3
+      expect(employee["firstName"]).to eq "John"
+      expect(employee["lastName"]).to eq "Doe"
+    end
 
-    info = @client.employee.job_info(1234)
+    it "Gets employee job info" do
+      response = File.new("spec/fixtures/job_info.xml")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
-    expect(info).to be_a Hash
-    expect(info[:table][:row].first[:employeeId]).to eq "100"
+      info = @client.employee.job_info(1234)
 
-    info[:table][:row].first[:field].each do |f|
-      case f[:id]
-      when "location"
-        expect(f[:__content__]).to eq "New York Office"
-      when "division"
-        expect(f[:__content__]).to eq "Sprockets"
-      when "department"
-        expect(f[:__content__]).to eq "Research and Development"
-      when "jobTitle"
-        expect(f[:__content__]).to eq "Machinist"
-      when "reportsTo"
-        expect(f[:__content__]).to eq "John Smith"
+      expect(info).to be_a Hash
+      expect(info[:table][:row].first[:employeeId]).to eq "100"
+
+      info[:table][:row].first[:field].each do |f|
+        case f[:id]
+        when "location"
+          expect(f[:__content__]).to eq "New York Office"
+        when "division"
+          expect(f[:__content__]).to eq "Sprockets"
+        when "department"
+          expect(f[:__content__]).to eq "Research and Development"
+        when "jobTitle"
+          expect(f[:__content__]).to eq "Machinist"
+        when "reportsTo"
+          expect(f[:__content__]).to eq "John Smith"
+        end
       end
     end
-  end
 
-  it "Gets an employee's time off estimate" do
-    response = File.new("spec/fixtures/time_off_estimate.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+    it "Gets an employee's time off estimate" do
+      response = File.new("spec/fixtures/time_off_estimate.json")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
-    future = Time.now + (60 * 60 * 24 * 180)
-    estimate = @client.employee.time_off_estimate(1234, future)
+      future = Time.now + (60 * 60 * 24 * 180)
+      estimate = @client.employee.time_off_estimate(1234, future)
 
-    expect(estimate).to be_a Hash
-    expect(estimate["estimates"].keys).to match_array %w(end estimate)
-    expect(estimate["estimates"]["estimate"].count).to eq 2
-    expect(estimate["estimates"]["estimate"].first.keys)
-      .to match_array %w(timeOffType name units balance)
-  end
-
-  it "returns the proper url using employee email address" do
-    hashed = "4fdce145bab6d27d69e34403f99fd11c" # Hash of me@here.com
-    required_url = "http://x.bamboohr.com/employees/photos/?h=#{hashed}"
-
-    # Normal
-    url = @client.employee.photo_url("me@here.com")
-    expect(url).to eq required_url
-
-    # Email with spaces
-    url = @client.employee.photo_url(" me@here.com ")
-    expect(url).to eq required_url
-
-    # Uppercase emails
-    url = @client.employee.photo_url("ME@HERE.COM")
-    expect(url).to eq required_url
-  end
-
-  it "returns the proper url using employee id" do
-    response = File.new("spec/fixtures/employee_emails.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-    hashed = "4fdce145bab6d27d69e34403f99fd11c"
-    required_url = "http://x.bamboohr.com/employees/photos/?h=#{hashed}"
-
-    url = @client.employee.photo_url(123)
-    expect(url).to eq required_url
-  end
-
-  it "Gets all employee records which have changed since a given date" do
-    response = File.new("spec/fixtures/last_changed.json")
-    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-    employees = @client.employee.last_changed("2011-06-02T19:26:23+00:00")
-
-    expect(employees).to be_a Hash
-    expect(employees.keys.count).to eq 4
-  end
-
-  describe "#add" do
-    it "creates a new employee in BambooHR" do
-      xml = YAML.load_file("spec/fixtures/add_employee_xml.yml")
-      response = File.new("spec/fixtures/add_employee_response.json")
-      details = JSON.parse(File.read("spec/fixtures/add_employee_details.json"))
-
-      stub_request(:post, /.*api\.bamboohr\.com.*/)
-        .with(xml).to_return(response)
-
-      employee = @client.employee.add(details)
-      location = employee["headers"]["location"]
-
-      expect(location).to eq "https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"
+      expect(estimate).to be_a Hash
+      expect(estimate["estimates"].keys).to match_array %w(end estimate)
+      expect(estimate["estimates"]["estimate"].count).to eq 2
+      expect(estimate["estimates"]["estimate"].first.keys)
+        .to match_array %w(timeOffType name units balance)
     end
-  end
 
-  describe "#update" do
-    it "updates an employee in BambooHR" do
-      xml = YAML.load_file("spec/fixtures/update_employee_xml.yml")
-      response = File.new("spec/fixtures/update_employee_response.json")
-      details = JSON.parse(File.read("spec/fixtures/update_employee_details.json"))
-      url = "https://x:x@api.bamboohr.com/api/gateway.php/x/v1/employees/1234"
+    it "returns the proper url using employee email address" do
+      hashed = "4fdce145bab6d27d69e34403f99fd11c" # Hash of me@here.com
+      required_url = "http://x.bamboohr.com/employees/photos/?h=#{hashed}"
 
-      stub_request(:post, url).with(xml).to_return(response)
-      employee = @client.employee.update("1234", details)
-      expected_headers = {
-        "content-type" => ["application/json; charset=utf-8"],
-        "date"         => ["Tue, 17 Jun 2014 19:25:35 UTC"]
-      }
+      # Normal
+      url = @client.employee.photo_url("me@here.com")
+      expect(url).to eq required_url
 
-      expect(employee["headers"]).to eq(expected_headers)
+      # Email with spaces
+      url = @client.employee.photo_url(" me@here.com ")
+      expect(url).to eq required_url
+
+      # Uppercase emails
+      url = @client.employee.photo_url("ME@HERE.COM")
+      expect(url).to eq required_url
+    end
+
+    it "returns the proper url using employee id" do
+      response = File.new("spec/fixtures/employee_emails.json")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+      hashed = "4fdce145bab6d27d69e34403f99fd11c"
+      required_url = "http://x.bamboohr.com/employees/photos/?h=#{hashed}"
+
+      url = @client.employee.photo_url(123)
+      expect(url).to eq required_url
+    end
+
+    it "Gets all employee records which have changed since a given date" do
+      response = File.new("spec/fixtures/last_changed.json")
+      stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+      employees = @client.employee.last_changed("2011-06-02T19:26:23+00:00")
+
+      expect(employees).to be_a Hash
+      expect(employees.keys.count).to eq 4
+    end
+
+    describe "#add" do
+      it "creates a new employee in BambooHR" do
+        xml = YAML.load_file("spec/fixtures/add_employee_xml.yml")
+        response = File.new("spec/fixtures/add_employee_response.json")
+        details = JSON.parse(File.read("spec/fixtures/add_employee_details.json"))
+
+        stub_request(:post, /.*api\.bamboohr\.com.*/)
+          .with(xml).to_return(response)
+
+        employee = @client.employee.add(details)
+        location = employee["headers"]["location"]
+
+        expect(location).to eq "https://api.bamboohr.com/api/gateway.php/alphasights/v1/employees/44259"
+      end
+    end
+
+    describe "#update" do
+      it "updates an employee in BambooHR" do
+        xml = YAML.load_file("spec/fixtures/update_employee_xml.yml")
+        response = File.new("spec/fixtures/update_employee_response.json")
+        details = JSON.parse(File.read("spec/fixtures/update_employee_details.json"))
+        url = "https://x:x@api.bamboohr.com/api/gateway.php/x/v1/employees/1234"
+
+        stub_request(:post, url).with(xml).to_return(response)
+        employee = @client.employee.update("1234", details)
+        expected_headers = {
+          "content-type" => ["application/json; charset=utf-8"],
+          "date" => ["Tue, 17 Jun 2014 19:25:35 UTC"]
+        }
+
+        expect(employee["headers"]).to eq(expected_headers)
+      end
     end
   end
 end

--- a/spec/lib/bamboozled/api/time_tracking_spec.rb
+++ b/spec/lib/bamboozled/api/time_tracking_spec.rb
@@ -1,82 +1,84 @@
 require "spec_helper"
 
 RSpec.describe "Time Tracking" do
-  before do
-    @client = Bamboozled.client(subdomain: "x", api_key: "x")
-  end
-
-  describe '#record' do
-    context 'api success' do
-      it 'gets the given record' do
-        response = File.new("spec/fixtures/time_tracking_record_200_response.json")
-        stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-        record = @client.time_tracking.record('37_2301_REG')
-
-        expect(record).to be_a Hash
-        expect(record['payRate']).to eq('19.0000')
-        expect(record['employeeId']).to eq('40488')
-      end
+  context 'UK api domain specified' do
+    before do
+      @client = Bamboozled.client(subdomain: "x", api_domain: 'api.bamboohr.co.uk', api_key: "x")
     end
 
-    describe 'api failures' do
-      context 'bad api key' do
-        it 'should raise an error' do
-          response = File.new("spec/fixtures/time_tracking_record_401_response.json")
-          stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+    describe '#record' do
+      context 'api success' do
+        it 'gets the given record' do
+          response = File.new("spec/fixtures/time_tracking_record_200_response.json")
+          stub_request(:any, /.*api\.bamboohr\.co\.uk.*/).to_return(response)
 
-          expect do
-            @client.time_tracking.record('37_2301_REG')
-          end.to raise_error(Bamboozled::AuthenticationFailed)
-        end
-      end
-      context 'invalid company name' do
-        it 'should raise an error' do
-          response = File.new("spec/fixtures/time_tracking_record_404_response.json")
-          stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+          record = @client.time_tracking.record('37_2301_REG')
 
-          expect do
-            @client.time_tracking.record('37_2301_REG')
-          end.to raise_error(Bamboozled::NotFound)
-        end
-      end
-      context 'invalid time tracking id' do
-        it 'should raise an error' do
-          response = File.new("spec/fixtures/time_tracking_record_400_response.json")
-          stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-          expect do
-            @client.time_tracking.record('37_2301_REG')
-          end.to raise_error(Bamboozled::BadRequest)
+          expect(record).to be_a Hash
+          expect(record['payRate']).to eq('19.0000')
+          expect(record['employeeId']).to eq('40488')
         end
       end
     end
   end
 
-  describe '#add' do
-    describe 'api success' do
-      it 'should return a hash with the id of the created record' do
-        response = File.new("spec/fixtures/time_tracking_add_200_response.json")
-        stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+  context 'no api domain specified' do
+    before do
+      @client = Bamboozled.client(subdomain: "x", api_key: "x")
+    end
 
-        data = {
-          timeTrackingId: '37_2302_REG',
-          employeeId: '40488',
-          dateHoursWorked: '2016-08-12',
-          payRate: '19.00',
-          rateType: 'REG',
-          hoursWorked: '4.5760'
-        }
-        record = @client.time_tracking.add(data)
-        expect(record).to be_a Hash
-        expect(record['id']).to eq('37_2302_REG')
+    describe '#record' do
+      context 'api success' do
+        it 'gets the given record' do
+          response = File.new("spec/fixtures/time_tracking_record_200_response.json")
+          stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+          record = @client.time_tracking.record('37_2301_REG')
+
+          expect(record).to be_a Hash
+          expect(record['payRate']).to eq('19.0000')
+          expect(record['employeeId']).to eq('40488')
+        end
+      end
+
+      describe 'api failures' do
+        context 'bad api key' do
+          it 'should raise an error' do
+            response = File.new("spec/fixtures/time_tracking_record_401_response.json")
+            stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+            expect do
+              @client.time_tracking.record('37_2301_REG')
+            end.to raise_error(Bamboozled::AuthenticationFailed)
+          end
+        end
+        context 'invalid company name' do
+          it 'should raise an error' do
+            response = File.new("spec/fixtures/time_tracking_record_404_response.json")
+            stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+            expect do
+              @client.time_tracking.record('37_2301_REG')
+            end.to raise_error(Bamboozled::NotFound)
+          end
+        end
+        context 'invalid time tracking id' do
+          it 'should raise an error' do
+            response = File.new("spec/fixtures/time_tracking_record_400_response.json")
+            stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+            expect do
+              @client.time_tracking.record('37_2301_REG')
+            end.to raise_error(Bamboozled::BadRequest)
+          end
+        end
       end
     end
 
-    describe 'api failures' do
-      context 'employee id does not exist' do
-        it 'should not raise an error but should not have an object in the response payload' do
-          response = File.new("spec/fixtures/time_tracking_add_empty_response.json")
+    describe '#add' do
+      describe 'api success' do
+        it 'should return a hash with the id of the created record' do
+          response = File.new("spec/fixtures/time_tracking_add_200_response.json")
           stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
           data = {
@@ -89,33 +91,54 @@ RSpec.describe "Time Tracking" do
           }
           record = @client.time_tracking.add(data)
           expect(record).to be_a Hash
-          expect(record['headers']['content-length']).to eq('0')
+          expect(record['id']).to eq('37_2302_REG')
+        end
+      end
+
+      describe 'api failures' do
+        context 'employee id does not exist' do
+          it 'should not raise an error but should not have an object in the response payload' do
+            response = File.new("spec/fixtures/time_tracking_add_empty_response.json")
+            stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+            data = {
+              timeTrackingId: '37_2302_REG',
+              employeeId: '40488',
+              dateHoursWorked: '2016-08-12',
+              payRate: '19.00',
+              rateType: 'REG',
+              hoursWorked: '4.5760'
+            }
+            record = @client.time_tracking.add(data)
+            expect(record).to be_a Hash
+            expect(record['headers']['content-length']).to eq('0')
+          end
         end
       end
     end
-  end
 
-  describe '#adjust' do
-    describe 'api success' do
-      it 'should return a hash with the id of the created record' do
-        response = File.new("spec/fixtures/time_tracking_adjust_200_response.json")
-        stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
-
-        record = @client.time_tracking.adjust('37_2302_REG', '4.8')
-        expect(record).to be_a Hash
-        expect(record['id']).to eq('37_2302_REG')
-      end
-    end
-
-    describe 'api failures' do
-      context 'time tracking id does not exist' do
-        it 'should raise a Bad Request error' do
-          response = File.new("spec/fixtures/time_tracking_adjust_400_response.json")
+    describe '#adjust' do
+      describe 'api success' do
+        it 'should return a hash with the id of the created record' do
+          response = File.new("spec/fixtures/time_tracking_adjust_200_response.json")
           stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
 
-          expect do
-            @client.time_tracking.adjust('37_2303_REG', '4.8')
-          end.to raise_error(Bamboozled::BadRequest)
+          record = @client.time_tracking.adjust('37_2302_REG', '4.8')
+          expect(record).to be_a Hash
+          expect(record['id']).to eq('37_2302_REG')
+        end
+      end
+
+      describe 'api failures' do
+        context 'time tracking id does not exist' do
+          it 'should raise a Bad Request error' do
+            response = File.new("spec/fixtures/time_tracking_adjust_400_response.json")
+            stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+            expect do
+              @client.time_tracking.adjust('37_2303_REG', '4.8')
+            end.to raise_error(Bamboozled::BadRequest)
+          end
         end
       end
     end

--- a/spec/lib/bamboozled/base_spec.rb
+++ b/spec/lib/bamboozled/base_spec.rb
@@ -4,23 +4,28 @@ RSpec.describe "Bamboozled::Base" do
   let(:base) { Bamboozled::Base.new(subdomain: "x", api_key: "x", httparty_options: {log_format: :curl}) }
 
   it "passes HTTParty options to Bamboozled::API::Employee constructor" do
-    expect(Bamboozled::API::Employee).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::Employee)
+      .to receive(:new).with({subdomain: "x", api_domain: nil}, "x", { log_format: :curl })
     base.employee
   end
   it "passes HTTParty options to Bamboozled::API::Report constructor" do
-    expect(Bamboozled::API::Report).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::Report)
+      .to receive(:new).with({subdomain: "x", api_domain: nil}, "x", { log_format: :curl })
     base.report
   end
   it "passes HTTParty options to Bamboozled::API::Meta constructor" do
-    expect(Bamboozled::API::Meta).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::Meta)
+      .to receive(:new).with({subdomain: "x", api_domain: nil}, "x", { log_format: :curl })
     base.meta
   end
   it "passes HTTParty options to Bamboozled::API::TimeOff constructor" do
-    expect(Bamboozled::API::TimeOff).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::TimeOff)
+      .to receive(:new).with({subdomain: "x", api_domain: nil}, "x", { log_format: :curl })
     base.time_off
   end
   it "passes HTTParty options to Bamboozled::API::TimeTracking constructor" do
-    expect(Bamboozled::API::TimeTracking).to receive(:new).with("x", "x", { log_format: :curl })
+    expect(Bamboozled::API::TimeTracking)
+      .to receive(:new).with({subdomain: "x", api_domain: nil}, "x", { log_format: :curl })
     base.time_tracking
   end
 end

--- a/spec/lib/bamboozled_spec.rb
+++ b/spec/lib/bamboozled_spec.rb
@@ -1,13 +1,34 @@
 require "spec_helper"
 
 RSpec.describe "Bamboozled" do
+  it "takes subdomain and api_domain options if first parameter is a hash" do
+    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_domain: "api.bamboohr.co.uk",
+                                                   api_key: "x", httparty_options: { log_format: :curl })
+    Bamboozled.client(subdomain: "x", api_domain: "api.bamboohr.co.uk", api_key: "x",
+                      httparty_options: { log_format: :curl })
+  end
+
   it "takes HTTParty options as a parameter" do
-    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
+    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_domain: nil, api_key: "x",
+                                                   httparty_options: { log_format: :curl })
     Bamboozled.client(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
   end
 
   it "throws no errors if no HTTParty options were provided (they are optional)" do
     expect { Bamboozled.client(subdomain: "x", api_key: "x") }.not_to raise_error
+  end
+
+  it "properly handles api domain when specified" do
+    logger = double("logger")
+    allow(Time).to receive_message_chain(:now, :strftime).and_return("Time.now")
+    expect(logger).to receive(:info).with('[HTTParty] [Time.now] 200 "GET https://api.bamboohr.co.uk/api/gateway.php/x/v1/employees/1234?fields=" - ')
+
+    client = Bamboozled.client(subdomain: "x", api_domain: "api.bamboohr.co.uk", api_key: "x",
+                               httparty_options: { log_format: :apache, logger: logger })
+    response = File.new("spec/fixtures/one_employee.json")
+    stub_request(:any, /.*api\.bamboohr\.co\.uk.*/).to_return(response)
+
+    client.employee.find(1234)
   end
 
   it "passes HTTParty params to HTTParty" do


### PR DESCRIPTION
For BambooHR customers outside the USA, such as those in the UK, allow the API domain to be specified when initializing the client.

The `Bamboozled.client()` initializer method now takes a `api_domain` parameter along with the others.  An example of a valid value here would be `api.bamboohr.co.uk`.

If no `api_domain` parameter has been specified, it defaults to `api.bamboohr.com`.