### PR TITLE
Rubocop fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ rvm:
   - jruby-head
 
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 install:
-  - bundle install --retry=3
+  - bundle install --retry=3 --deployment
 
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ rvm:
   - ruby-head
   - jruby-head
 
-before_install: gem update --remote bundler && bundle --version
+before_install:
+  - gem update --system
+  - gem install bundler
 install:
   - bundle install --retry=3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ rvm:
   - ruby-head
   - jruby-head
 
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
-install:
-  - bundle install --retry=3
-
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
 install:
-  - bundle install --retry=3 --deployment
+  - bundle install --retry=3
 
 script:
   - bundle exec rspec

--- a/bamboozled.gemspec
+++ b/bamboozled.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "bamboozled/version"
 

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -13,73 +13,73 @@ module Bamboozled
       end
 
       protected
-        def request(method, path, options = {})
-          params = {
-            path:    path,
-            options: options,
-            method:  method
-          }
+      def request(method, path, options = {})
+        params = {
+          path:    path,
+          options: options,
+          method:  method
+        }
 
-          httparty_options = @httparty_options.merge({
-            query:  options[:query],
-            body:   options[:body],
-            format: :plain,
-            basic_auth: auth,
-            headers: {
-              "Accept"       => "application/json",
-              "User-Agent"   => "Bamboozled/#{Bamboozled::VERSION}"
-            }.update(options[:headers] || {})
-          })
+        httparty_options = @httparty_options.merge({
+          query:  options[:query],
+          body:   options[:body],
+          format: :plain,
+          basic_auth: auth,
+          headers: {
+            "Accept"       => "application/json",
+            "User-Agent"   => "Bamboozled/#{Bamboozled::VERSION}"
+          }.update(options[:headers] || {})
+        })
 
-          response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
-          params[:response] = response.inspect.to_s
+        response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
+        params[:response] = response.inspect.to_s
 
-          case response.code
-          when 200..201
-            begin
-              if response.body.to_s.empty?
-                { "headers" => response.headers }
-              else
-                JSON.parse(response)
-              end
-            rescue
-              typecast = options.fetch(:typecast_values, true)
-              MultiXml.parse(response,
-                             symbolize_keys: true,
-                             typecast_xml_value: typecast)
+        case response.code
+        when 200..201
+          begin
+            if response.body.to_s.empty?
+              { "headers" => response.headers }
+            else
+              JSON.parse(response)
             end
-          when 400
-            raise Bamboozled::BadRequest.new(response, params, 'The request was invalid or could not be understood by the server. Resubmitting the request will likely result in the same error.')
-          when 401
-            raise Bamboozled::AuthenticationFailed.new(response, params, 'Your API key is missing.')
-          when 403
-            raise Bamboozled::Forbidden.new(response, params, 'The application is attempting to perform an action it does not have privileges to access. Verify your API key belongs to an enabled user with the required permissions.')
-          when 404
-            raise Bamboozled::NotFound.new(response, params, 'The resource was not found with the given identifier. Either the URL given is not a valid API, or the ID of the object specified in the request is invalid.')
-          when 406
-            raise Bamboozled::NotAcceptable.new(response, params, 'The request contains references to non-existent fields.')
-          when 409
-            raise Bamboozled::Conflict.new(response, params, 'The request attempts to create a duplicate. For employees, duplicate emails are not allowed. For lists, duplicate values are not allowed.')
-          when 429
-            raise Bamboozled::LimitExceeded.new(response, params, 'The account has reached its employee limit. No additional employees could be added.')
-          when 500
-            raise Bamboozled::InternalServerError.new(response, params, 'The server encountered an error while processing your request and failed.')
-          when 502
-            raise Bamboozled::GatewayError.new(response, params, 'The load balancer or web server had trouble connecting to the Bamboo app. Please try the request again.')
-          when 503
-            raise Bamboozled::ServiceUnavailable.new(response, params, 'The service is temporarily unavailable. Please try the request again.')
-          else
-            raise Bamboozled::InformBamboo.new(response, params, 'An error occurred that we do not now how to handle. Please contact BambooHR.')
+          rescue
+            typecast = options.fetch(:typecast_values, true)
+            MultiXml.parse(response,
+                           symbolize_keys: true,
+                           typecast_xml_value: typecast)
           end
+        when 400
+          raise Bamboozled::BadRequest.new(response, params, 'The request was invalid or could not be understood by the server. Resubmitting the request will likely result in the same error.')
+        when 401
+          raise Bamboozled::AuthenticationFailed.new(response, params, 'Your API key is missing.')
+        when 403
+          raise Bamboozled::Forbidden.new(response, params, 'The application is attempting to perform an action it does not have privileges to access. Verify your API key belongs to an enabled user with the required permissions.')
+        when 404
+          raise Bamboozled::NotFound.new(response, params, 'The resource was not found with the given identifier. Either the URL given is not a valid API, or the ID of the object specified in the request is invalid.')
+        when 406
+          raise Bamboozled::NotAcceptable.new(response, params, 'The request contains references to non-existent fields.')
+        when 409
+          raise Bamboozled::Conflict.new(response, params, 'The request attempts to create a duplicate. For employees, duplicate emails are not allowed. For lists, duplicate values are not allowed.')
+        when 429
+          raise Bamboozled::LimitExceeded.new(response, params, 'The account has reached its employee limit. No additional employees could be added.')
+        when 500
+          raise Bamboozled::InternalServerError.new(response, params, 'The server encountered an error while processing your request and failed.')
+        when 502
+          raise Bamboozled::GatewayError.new(response, params, 'The load balancer or web server had trouble connecting to the Bamboo app. Please try the request again.')
+        when 503
+          raise Bamboozled::ServiceUnavailable.new(response, params, 'The service is temporarily unavailable. Please try the request again.')
+        else
+          raise Bamboozled::InformBamboo.new(response, params, 'An error occurred that we do not now how to handle. Please contact BambooHR.')
         end
+      end
 
-        def auth
-          { username: api_key, password: "x" }
-        end
+      def auth
+        { username: api_key, password: "x" }
+      end
 
-        def path_prefix
-          "https://api.bamboohr.com/api/gateway.php/#{subdomain}/v1/"
-        end
+      def path_prefix
+        "https://api.bamboohr.com/api/gateway.php/#{subdomain}/v1/"
+      end
     end
   end
 end

--- a/lib/bamboozled/api/report.rb
+++ b/lib/bamboozled/api/report.rb
@@ -2,8 +2,8 @@ module Bamboozled
   module API
     class Report < Base
 
-      def find(number, format = 'JSON', fd = true)
-        request(:get, "reports/#{number}?format=#{format.upcase}&fd=#{fd.yesno}")
+      def find(number, format = 'JSON', fd_param = true)
+        request(:get, "reports/#{number}?format=#{format.upcase}&fd=#{fd_param.yesno}")
       end
 
       # TODO - Implement custom reports


### PR DESCRIPTION
Currently the travis build is failing off master.  I think that's because the rubocop version is not specified, and some rules changed when it got updated.

In this MR:
* rubocop fixes
* reverting to default commands in travis.yml (additional install commands was causing certain ruby versions to fail)