### PR TITLE
ensure JSON.parse gets a string, not an HTTParty::Response object

### DIFF
--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -37,10 +37,11 @@ module Bamboozled
         case response.code
         when 200..201
           begin
-            if response.body.to_s.empty?
+            body = response.body.to_s
+            if body.empty?
               { "headers" => response.headers }
             else
-              JSON.parse(response)
+              JSON.parse(body)
             end
           rescue
             typecast = options.fetch(:typecast_values, true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There was already some normalization of `response.body` to a string, so I pulled that out above the parsing so it could be re-used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #65 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
