### PR TITLE
Bump gem dependencies to latest.

### DIFF
--- a/bamboozled.gemspec
+++ b/bamboozled.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "webmock", "~> 1.20"
 
-  spec.add_dependency "httparty", "~> 0.13"
-  spec.add_dependency "json", "~> 1.8"
+  spec.add_dependency "httparty", "~> 0.17"
+  spec.add_dependency "json", "~> 2"
 end


### PR DESCRIPTION
Hi! 👋 

We got a dependency update PR that bumped `bamboozled` from 0.0.7 to 0.2.0 and
downgraded `json` from 2.2.0 to 1.8.6.

After closer inspection of this gem dependencies it seems that it would be
super safe to upgrade both `json` and `httparty` to their latest versions.

`json` changelog shows no breaking changes but dropping support to old Rubies
https://github.com/flori/json/blob/8d8e1aa70297d55034e3f6a4ce2f32300294b2a4/CHANGES.md

`httparty` changelog shows no breaking changes but dropping support to Ruby <
2 https://github.com/jnunemaker/httparty/blob/99751ac98af929b315c74c2ac0f5ffa09195f7ae/Changelog.md

The gem already requires Ruby >= 2.0 based on the gemspec `spec.required_ruby_version = ">= 2.0"`.

Thanks for considering this change 💜 
